### PR TITLE
SyntaxEditor ペーストコマンドの差し替えサンプル実装

### DIFF
--- a/syntaxeditor/ViewModel/SyntaxEditorGettingStartedViewModel.cs
+++ b/syntaxeditor/ViewModel/SyntaxEditorGettingStartedViewModel.cs
@@ -79,6 +79,8 @@ namespace syncfusion.syntaxeditordemos.wpf
         /// </summary>
         private ICommand editLoadedCommand;
 
+        private ICommand myPasteCommand;
+
         /// <summary>
         /// Initializes the instance of<see cref="SyntaxEditorGettingStartedViewModel"/>class
         /// </summary>
@@ -96,6 +98,16 @@ namespace syncfusion.syntaxeditordemos.wpf
             insertSpaceCommand = new DelegateCommand<object>(ExecuteInsertSpaceCommand);
             singleLineCommand = new DelegateCommand<object>(ExecuteSingleLineCommand);
             editLoadedCommand = new DelegateCommand<object>(ExecuteEditLoaded);
+
+            myPasteCommand = new DelegateCommand<object>(ExecuteMyPasteCommand);
+        }
+
+        public ICommand MyPasteCommand
+        {
+            get
+            {
+                return myPasteCommand;
+            }
         }
 
         /// <summary>
@@ -324,6 +336,11 @@ namespace syncfusion.syntaxeditordemos.wpf
             {
                 (param as EditControl).StatusBarSettings.Visibility = Visibility.Collapsed;
             }
+        }
+
+        private void ExecuteMyPasteCommand(object param)
+        {
+            MessageBox.Show("ペースト実行");
         }
     }
 }

--- a/syntaxeditor/Views/GettingStarted.xaml
+++ b/syntaxeditor/Views/GettingStarted.xaml
@@ -40,7 +40,14 @@
                 </MenuItem.Icon>
             </MenuItem>
 
+            <!--
             <MenuItem Header="Paste" Command="{x:Static syncfusion:EditCommands.Paste}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Paste.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+            -->
+            <MenuItem Header="Paste" Command="{Binding MyPasteCommand}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
                 <MenuItem.Icon>
                     <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Paste.png" />
                 </MenuItem.Icon>
@@ -113,7 +120,7 @@
                 <MenuItem Command="{x:Static syncfusion:EditCommands.Redo}" CommandTarget="{Binding ElementName=editControl}" />
                 <MenuItem Command="{x:Static syncfusion:EditCommands.Cut}" CommandTarget="{Binding ElementName=editControl}"  />
                 <MenuItem Command="{x:Static syncfusion:EditCommands.Copy}" CommandTarget="{Binding ElementName=editControl}" />
-                <MenuItem Command="{x:Static syncfusion:EditCommands.Paste}" CommandTarget="{Binding ElementName=editControl}" />
+                <MenuItem Header="Paste" Command="{Binding MyPasteCommand}" CommandTarget="{Binding ElementName=editControl}"/>
                 <MenuItem Command="{x:Static syncfusion:EditCommands.SelectAll}" CommandTarget="{Binding ElementName=editControl}" />
                 <MenuItem Header="Find and Replace">
                     <MenuItem Command="{x:Static syncfusion:EditCommands.Find}" CommandTarget="{Binding ElementName=editControl}" />

--- a/syntaxeditor/Views/GettingStarted.xaml
+++ b/syntaxeditor/Views/GettingStarted.xaml
@@ -8,10 +8,77 @@
     xmlns:skinManager="clr-namespace:Syncfusion.SfSkinManager;assembly=Syncfusion.SfSkinManager.WPF"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
-    x:Name="window" Margin="8">
+    x:Name="window" Margin="8" OptionsSize="200">
     <democommon:DemoControl.DataContext>
         <local:SyntaxEditorGettingStartedViewModel />
     </democommon:DemoControl.DataContext>
+
+    <democommon:DemoControl.Resources>
+        <!-- https://www.syncfusion.com/kb/8903/how-to-add-custom-menu-items-to-editcontrol-embedded-contextmenu -->
+        <ContextMenu x:Key="contextmenu">
+            <MenuItem Header="Undo" Command="{x:Static syncfusion:EditCommands.Undo}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Undo.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Redo" Command="{x:Static syncfusion:EditCommands.Redo}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Redo.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Cut" Command="{x:Static syncfusion:EditCommands.Cut}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Cut.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Copy" Command="{x:Static syncfusion:EditCommands.Copy}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Copy.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Paste" Command="{x:Static syncfusion:EditCommands.Paste}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Paste.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="SelectAll" Command="{x:Static syncfusion:EditCommands.SelectAll}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}"></MenuItem>
+
+            <MenuItem Header="Outlining">
+                <MenuItem Header="ExpandallText" Command="{x:Static syncfusion:EditCommands.ExpandAll}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}"></MenuItem>
+                <MenuItem Header="Collapseall" Command="{x:Static syncfusion:EditCommands.CollapseAll}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}"></MenuItem>
+            </MenuItem>
+
+            <MenuItem Header="Increaseindent" Command="{x:Static syncfusion:EditCommands.IncreaseIndent}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/IncreaseIndent.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Decreaseindent" Command="{x:Static syncfusion:EditCommands.DecreaseIndent}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/DecreaseIndent.png" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Commentlines" Command="{x:Static syncfusion:EditCommands.CommentSelection}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Comment.png" MaxHeight="16" MaxWidth="16" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="Uncommentlines" Command="{x:Static syncfusion:EditCommands.UncommentSelection}" CommandTarget="{Binding RelativeSource={RelativeSource AncestorType={x:Type syncfusion:EditControl}}}">
+                <MenuItem.Icon>
+                    <Image Source="pack://application:,,,/Syncfusion.Edit.Wpf;component/Resources/Uncomment.png" MaxHeight="16" MaxWidth="16" />
+                </MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+    </democommon:DemoControl.Resources>
+
     <Grid>
         <Grid.Resources>
             <ResourceDictionary>
@@ -241,17 +308,20 @@
             AllowDrop="True"
             BorderThickness="0"
             DocumentSource="{Binding DocumentSource}"
+            ContextMenu="{StaticResource contextmenu}"
+            ShowDefaultContextMenu="False"
             EnableOutlining="False"
             FontFamily="{Binding ElementName=fontlist, Path=SelectedItem}"
             FontSize="{Binding ElementName=fontsize, Path=SelectedItem}"
             IsMultiLine="{Binding SingleLineChecked}"
             ShowLineNumber="{Binding LineNumber}"
-            TabKeyBehavior="{Binding TabBehavior}">
+            TabKeyBehavior="{Binding TabBehavior}" Cursor="IBeam">
             <interactivity:Interaction.Triggers>
                 <interactivity:EventTrigger EventName="Loaded">
                     <interactivity:InvokeCommandAction Command="{Binding EditLoadedCommand}" CommandParameter="{Binding ElementName=editControl}" />
                 </interactivity:EventTrigger>
             </interactivity:Interaction.Triggers>
+
         </syncfusion:EditControl>
     </Grid>
 </democommon:DemoControl>

--- a/syntaxeditor/Views/GettingStarted.xaml.cs
+++ b/syntaxeditor/Views/GettingStarted.xaml.cs
@@ -7,6 +7,8 @@
 #endregion
 
 using syncfusion.demoscommon.wpf;
+using System;
+using System.Windows;
 
 namespace syncfusion.syntaxeditordemos.wpf
 {
@@ -22,11 +24,15 @@ namespace syncfusion.syntaxeditordemos.wpf
         public GettingStarted()
         {
             InitializeComponent();
+
         }
 
         public GettingStarted(string themename) : base(themename)
         {
             InitializeComponent();
+
+            // AddPastingHandler ‚ÍŒø‚©‚È‚¢–Í—l
+            // DataObject.AddPastingHandler(editControl, OnPaseteHandler);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
[GettingStarted.xaml](https://github.com/syncfusion/wpf-demos/blob/bf072b55ee1ee049ea818793fae09e7e52811ae9/syntaxeditor/Views/GettingStarted.xaml#L16-L87)

1. SyncFusionの埋め込みコンテキストメニューと同じ内容のメニューを定義し、設定する
2. 挙動を変更したいコマンドを差し替え
3. コマンドを実装する